### PR TITLE
Trigger scheduled build always

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,11 @@ pr:
 
 schedules:
 - cron: "0 */2 * * *"
-  displayName: Hourly build
+  displayName: Bi-hourly build
   branches:
     include:
     - master
+  always: true
 
 stages:
   - stage: Build_platforms


### PR DESCRIPTION
I had not seen this:
```yaml
always: boolean # whether to always run the pipeline or only if there have been source code changes since the last run. The default is false.
```