### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/web/bsconfig.json
+++ b/web/bsconfig.json
@@ -19,7 +19,7 @@
   "bs-dependencies": [
     "reason-react",
     "bs-fetch",
-    "@aantron/repromise"
+    "reason-promise"
   ],
   "bs-dev-dependencies": [],
   "warnings": {

--- a/web/lib/js/search/pkg_index_data.bs.js
+++ b/web/lib/js/search/pkg_index_data.bs.js
@@ -5,7 +5,7 @@ var List = require("bs-platform/lib/js/list.js");
 var $$Array = require("bs-platform/lib/js/array.js");
 var Js_json = require("bs-platform/lib/js/js_json.js");
 var Package = require("../model/package.bs.js");
-var Repromise = require("@aantron/repromise/lib/js/src/js/repromise.js");
+var $$Promise = require("reason-promise/lib/js/src/js/promise.js");
 var Caml_array = require("bs-platform/lib/js/caml_array.js");
 var Belt_Option = require("bs-platform/lib/js/belt_Option.js");
 
@@ -29,9 +29,9 @@ function parse(json) {
 }
 
 function load(param) {
-  return Repromise.Rejectable[/* map */5](parse, Repromise.Rejectable[/* fromJsPromise */10](fetch("https://raw.githubusercontent.com/reuniverse/reuniverse/master/packages/index.json").then((function (prim) {
+  return $$Promise.Js[/* map */5]($$Promise.Js[/* fromBsPromise */13](fetch("https://raw.githubusercontent.com/reuniverse/reuniverse/master/packages/index.json").then((function (prim) {
                         return prim.json();
-                      }))));
+                      }))), parse);
 }
 
 var unwrap = Belt_Option.getExn;

--- a/web/lib/js/search/search.bs.js
+++ b/web/lib/js/search/search.bs.js
@@ -5,7 +5,7 @@ var List = require("bs-platform/lib/js/list.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var React = require("react");
 var Package = require("../model/package.bs.js");
-var Repromise = require("@aantron/repromise/lib/js/src/js/repromise.js");
+var $$Promise = require("reason-promise/lib/js/src/js/promise.js");
 var Ds_loading = require("../design_system/ds_loading.bs.js");
 var Ds_container = require("../design_system/ds_container.bs.js");
 var Ds_tiny_title = require("../design_system/ds_tiny_title.bs.js");
@@ -27,12 +27,12 @@ function load_index(state, setState) {
   React.useEffect((function () {
           var match = state[/* index */0];
           if (match === undefined) {
-            Repromise.Rejectable[/* map */5]((function (index) {
+            $$Promise.Js[/* map */5](Pkg_index_data.load(/* () */0), (function (index) {
                     Curry._1(setState, (function (param) {
                             return /* record */[/* index */index];
                           }));
-                    return Repromise.Rejectable[/* resolved */2](/* () */0);
-                  }), Pkg_index_data.load(/* () */0));
+                    return $$Promise.Js[/* resolved */1](/* () */0);
+                  }));
           }
           return undefined;
         }));

--- a/web/package.json
+++ b/web/package.json
@@ -19,8 +19,8 @@
     "fastpack": "^0.8.4"
   },
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
     "bs-fetch": "^0.5.0",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.7.0"
   }
 }

--- a/web/search/pkg_index_data.re
+++ b/web/search/pkg_index_data.re
@@ -44,12 +44,12 @@ let parse: Js.Json.t => Model.Index.t =
     {package_count, packages};
   };
 
-let load: unit => Repromise.rejectable(Model.Index.t, _) =
+let load: unit => Promise.Js.t(Model.Index.t, _) =
   () => {
-    Fetch.fetch(
+    (Fetch.fetch(
       "https://raw.githubusercontent.com/reuniverse/reuniverse/master/packages/index.json",
     )
-    |> Js.Promise.then_(Fetch.Response.json)
-    |> Repromise.Rejectable.fromJsPromise
-    |> Repromise.Rejectable.map(parse);
+    |> Js.Promise.then_(Fetch.Response.json))
+    ->Promise.Js.fromBsPromise
+    ->Promise.Js.map(parse);
   };

--- a/web/search/search.re
+++ b/web/search/search.re
@@ -12,9 +12,9 @@ module Effects = {
       switch (State.(state.index)) {
       | None =>
         Pkg_index_data.load()
-        |> Repromise.Rejectable.map(index => {
+        ->Promise.Js.map(index => {
              setState(_ => State.make(~index));
-             Repromise.Rejectable.resolved();
+             Promise.Js.resolved();
            })
         |> ignore
       | Some(_) => ()

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@aantron/repromise@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@aantron/repromise/-/repromise-0.6.0.tgz#45bea66e593b7e0f968bc0fd03f0b6578003e698"
-  integrity sha512-nxNUWKQQhRJKmsExKi2qyZUryvpEz07H17fEhRaZC3wXkxCtjcdx9j5LMnV0+anbU+EyG/X+UnfATReerBZgMA==
-
 bs-fetch@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.5.0.tgz#6913b1d1ddfa0b0a4b832357854e9763d61d4b28"
@@ -79,6 +74,11 @@ react@>=16.8.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+reason-promise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
+  integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
 reason-react@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
Repromise became [reason-promise](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.